### PR TITLE
Add test-unit as dev dependency

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
   s.add_dependency "httparty", "~> 0.10.0"
   s.add_dependency "public_suffix", "~> 1.2.0"
+  s.add_development_dependency "test-unit"
   s.add_development_dependency "shoulda"
   s.add_development_dependency "fakeweb"
   s.add_development_dependency "rake", "~> 0.9"


### PR DESCRIPTION
## What? Why?

As a prequel to updating the `public_suffix` gem, gotta get the test suite to run!

The test suite doesn't currently run on Ruby 2 since TestUnit has been deprecated in favor of MiniTest. This PR adds [TestUnit](https://github.com/test-unit/test-unit) as a gem.
## Additional Deploy Steps?

None
## How was it tested?

To replicate issue:
- Checkout master
- Switch to Ruby 2 something: `rvm use ruby-2.0.0-p481`
- Install dependencies: `bundle install --clean`
- Verify test suite fails: `bundle exec rake`

Now:
- Checkout my branch
- Switch to Ruby 2 something: `rvm use ruby-2.0.0-p481`
- Install dependencies: `bundle install --clean`
- Verify test suite runs as expected: `bundle exec rake`

cc @IamDavidovich @splittingred @jlleblanc @charrisbc 
