### PR TITLE
Update public_suffix gem to 1.4.6

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "enom"
-  s.version = "1.1.2"
+  s.version = "1.1.3"
   s.authors = ["James Miller"]
   s.summary = %q{Ruby wrapper for the Enom API}
   s.description = %q{Enom is a Ruby wrapper and command line interface for portions of the Enom domain reseller API.}
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files  = %w( README.md Rakefile LICENSE ) + ["lib/enom.rb"] + Dir.glob("lib/enom/*.rb") + Dir.glob("lib/enom/commands/*.rb") + Dir.glob("test/**/*") + Dir.glob("bin/*")
   s.has_rdoc = false
   s.add_dependency "httparty", "~> 0.10.0"
-  s.add_dependency "public_suffix", "~> 1.2.0"
+  s.add_dependency "public_suffix", "~> 1.4.6"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "shoulda"
   s.add_development_dependency "fakeweb"

--- a/test/domain_test.rb
+++ b/test/domain_test.rb
@@ -246,6 +246,16 @@ class DomainTest < Test::Unit::TestCase
         end
       end
     end
+
+    context "finding the latest tlds in your account" do
+      setup do
+        @domain = Enom::Domain.find("test123456test123456.beer")
+      end
+
+      should "return a domain object" do
+        assert_kind_of Enom::Domain, @domain
+      end
+    end
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -337,6 +337,112 @@ class Test::Unit::TestCase
       EOF
     },
     {
+      :command => "GetDomainInfo (Success)",
+      :request => "https://reseller.enom.com/interface.asp?Command=GetDomainInfo&SLD=test123456test123456&TLD=beer&UID=resellid&PW=resellpw&ResponseType=xml",
+      :response => <<-EOF
+      <?xml version="1.0"?>
+        <interface-response>
+          <GetDomainInfo>
+            <domainname sld="test123456test123456" tld="beer" domainnameid="340724808">test123456test123456.beer</domainname>
+            <multy-langSLD></multy-langSLD>
+            <status>
+              <expiration>1/30/2012 5:23:00 PM</expiration>
+              <escrowliftdate/>
+              <escrowhold/>
+              <deletebydate>1/30/2012 5:23:00 PM</deletebydate>
+              <deletetype/>
+              <registrar>eNom, Inc.</registrar>
+              <registrationstatus>Registered</registrationstatus>
+              <purchase-status>Paid</purchase-status>
+              <belongs-to party-id="{CF869235-0083-4BB0-99DF-DCEAC6F2294E}">resellid</belongs-to>
+            </status>
+            <ParkingEnabled>False</ParkingEnabled>
+            <services>
+              <entry name="dnsserver">
+                <enomDNS value="YES" isDotName="NO"/>
+                <service changable="1">1006</service>
+                <configuration changable="0" type="dns">
+                  <dns>dns1.name-services.com</dns>
+                  <dns>dns2.name-services.com</dns>
+                  <dns>dns3.name-services.com</dns>
+                  <dns>dns4.name-services.com</dns>
+                  <dns>dns5.name-services.com</dns>
+                </configuration>
+              </entry>
+              <entry name="dnssettings">
+                <service changable="0">1021</service>
+                <configuration changable="1" type="host">
+                  <host>
+                    <name><![CDATA[*]]></name>
+                    <type><![CDATA[A]]></type>
+                    <address><![CDATA[69.25.142.5]]></address>
+                    <mxpref><![CDATA[10]]></mxpref>
+                    <iseditable><![CDATA[1]]></iseditable>
+                  </host>
+                  <host>
+                    <name><![CDATA[@]]></name>
+                    <type><![CDATA[A]]></type>
+                    <address><![CDATA[69.25.142.5]]></address>
+                    <mxpref><![CDATA[10]]></mxpref>
+                    <iseditable><![CDATA[1]]></iseditable>
+                  </host>
+                  <host>
+                    <name><![CDATA[www]]></name>
+                    <type><![CDATA[A]]></type>
+                    <address><![CDATA[69.25.142.5]]></address>
+                    <mxpref><![CDATA[10]]></mxpref>
+                    <iseditable><![CDATA[1]]></iseditable>
+                  </host>
+                </configuration>
+              </entry>
+              <entry name="wsb">
+                <service changable="1">1060</service>
+              </entry>
+              <entry name="emailset">
+                <service changable="1">1048</service>
+              </entry>
+              <entry name="wpps">
+                <service changable="1">1123</service>
+              </entry>
+              <entry name="wbl">
+                <wbl>
+                  <statusid><![CDATA[0]]></statusid>
+                  <statusdescr><![CDATA[Available]]></statusdescr>
+                </wbl>
+              </entry>
+              <entry name="mobilizer">
+                <service changable="0">1117</service>
+                <mobilizer/>
+              </entry>
+              <entry name="parking">
+                <service changable="1">1033</service>
+              </entry>
+              <entry name="messaging">
+                <service changable="1">1087</service>
+              </entry>
+              <entry name="map">
+                <service changable="1">1108</service>
+              </entry>
+            </services>
+          </GetDomainInfo>
+          <Command>GETDOMAININFO</Command>
+          <Language>eng</Language>
+          <ErrCount>0</ErrCount>
+          <ResponseCount>0</ResponseCount>
+          <MinPeriod>1</MinPeriod>
+          <MaxPeriod>10</MaxPeriod>
+          <Server>RESELLERTEST</Server>
+          <Site>eNom</Site>
+          <IsLockable>True</IsLockable>
+          <IsRealTimeTLD>True</IsRealTimeTLD>
+          <TimeDifference>+08.00</TimeDifference>
+          <ExecTime>0.344</ExecTime>
+          <Done>true</Done>
+          <debug><![CDATA[]]></debug>
+        </interface-response>
+      EOF
+    },
+    {
       :command => "Extend (Success)",
       :request => "https://reseller.enom.com/interface.asp?Command=Extend&SLD=test123456test123456&TLD=com&UID=resellid&PW=resellpw&ResponseType=xml",
       :response => <<-EOF


### PR DESCRIPTION
## What? Why?

Bumps the public_suffix gem to the latest version to allow the latest TLDs to be used.

This PR:
- Updates the public_suffix gem to the latest tagged version (1.4.6)
- Adds a new test that given a TLD from the latest public_suffix definitions file (https://github.com/weppos/publicsuffix-ruby/commit/df4b9e0d47dd575b2c5bda6088c5687d6a92b550#diff-6af66fb96ba3676c54785b92b8e0462f), confirms the domain can be parsed. An error similar to `PublicSuffix::DomainInvalid: `test123456test123456.beer' is not a valid domain` will be generated if the TLD isn't recognized by public_suffix.
## Additional Deploy Steps?
- Depends on bigcommerce-labs/enom#1 being merged first so the test suite will run.
## How was it tested?

`bundle exec rake`

cc @IamDavidovich @splittingred @jlleblanc @charrisbc 
