### PR TITLE
Bump public_suffix gem to 1.5.3

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "enom"
-  s.version = "1.1.5"
+  s.version = "1.1.6"
   s.authors = ["James Miller"]
   s.summary = %q{Ruby wrapper for the Enom API}
   s.description = %q{Enom is a Ruby wrapper and command line interface for portions of the Enom domain reseller API.}
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files  = %w( README.md Rakefile LICENSE ) + ["lib/enom.rb"] + Dir.glob("lib/enom/*.rb") + Dir.glob("lib/enom/commands/*.rb") + Dir.glob("test/**/*") + Dir.glob("bin/*")
   s.has_rdoc = false
   s.add_dependency "httparty", "~> 0.10.0"
-  s.add_dependency "public_suffix", "~> 1.4.6"
+  s.add_dependency "public_suffix", "~> 1.5.3"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "shoulda"
   s.add_development_dependency "fakeweb"


### PR DESCRIPTION
This PR updates the public_suffix gem to version 1.5.3.

## How to test
Automatically: `bundle exec rake`
Manually: `PublicSuffix.valid?('store.online')` should return `true`.