### PR TITLE
BRP-3005: avoid PublicSuffix calls when TLD is available

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "enom"
-  s.version = "1.1.6"
+  s.version = "1.1.7"
   s.authors = ["James Miller"]
   s.summary = %q{Ruby wrapper for the Enom API}
   s.description = %q{Enom is a Ruby wrapper and command line interface for portions of the Enom domain reseller API.}

--- a/lib/enom/domain.rb
+++ b/lib/enom/domain.rb
@@ -40,20 +40,30 @@ module Enom
     end
 
     # Find the domain (must be in your account) on Enom
-    def self.find(name)
-      sld, tld = parse_sld_and_tld(name)
+    def self.find(name, tld = nil)
+      if tld.present?
+        sld = name
+      else
+        sld, tld = parse_sld_and_tld(name)
+      end
+
       response = Client.request("Command" => "GetDomainInfo", "SLD" => sld, "TLD" => tld)["interface_response"]["GetDomainInfo"]
       Domain.new(response)
     end
 
     # Determine if the domain is available for purchase
-    def self.check(name)
-      available?(name) ? "available" : "unavailable"
+    def self.check(name, tld = nil)
+      available?(name, tld) ? "available" : "unavailable"
     end
 
     # Boolean helper method to determine if the domain is available for purchase
-    def self.available?(name)
-      sld, tld = parse_sld_and_tld(name)
+    def self.available?(name, tld = nil)
+      if tld.present?
+        sld = name
+      else
+        sld, tld = parse_sld_and_tld(name)
+      end
+
       response = Client.request("Command" => "Check", "SLD" => sld, "TLD" => tld)["interface_response"]["RRPCode"]
       response == "210"
     end


### PR DESCRIPTION
Calls to `parse_sld_and_tld` are problematic if you are trying to avoid validating a domain through `PublicSuffix`. This PR allows a `tld` to be passed through so that `PublicSuffix` parsing can be bypassed. If a `tld` is available, it is used, otherwise `parse_sld_and_tld` is used as a fallback.