### PR TITLE
Domain renew ensures the expiration date is the date from the renew response

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "enom"
-  s.version = "1.1.7"
+  s.version = "1.1.8"
   s.authors = ["James Miller"]
   s.summary = %q{Ruby wrapper for the Enom API}
   s.description = %q{Enom is a Ruby wrapper and command line interface for portions of the Enom domain reseller API.}
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = false
   s.add_dependency "httparty", "~> 0.10.0"
   s.add_dependency "public_suffix", "~> 1.5.3"
+  s.add_dependency "activesupport", "> 4.2"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "shoulda"
   s.add_development_dependency "fakeweb"

--- a/test/domain_test.rb
+++ b/test/domain_test.rb
@@ -175,6 +175,11 @@ class DomainTest < Test::Unit::TestCase
         assert_kind_of Enom::Domain, @domain
         assert_equal @domain.name, "test123456test123456.com"
       end
+
+      should "return the domain reflecting the new expiration date" do
+        original_expiration_date = Enom::Domain.find('test123456test123456.com').expiration_date
+        assert_true (@domain.expiration_date - original_expiration_date).to_i > 365
+      end
     end
 
     context "renewing an expired domain" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -450,6 +450,9 @@ class Test::Unit::TestCase
         <interface-response>
           <Extension>successful</Extension>
           <DomainName>test123456test123456.com</DomainName>
+          <DomainInfo>
+            <RegistryExpDate>2013-01-30 19:07:50.000</RegistryExpDate>
+          </DomainInfo>
           <OrderID>157609742</OrderID>
           <RRPCode>200</RRPCode>
           <RRPText>Command completed successfully</RRPText>


### PR DESCRIPTION
# What / Why
When a domain is renewed, find requests on that domain are not guaranteed to reflect the expiration date. Now, when a domain is renewed, the found domain will have its expiration date updated to be the value of the previously successful extend command response.

Also, `lib/enom/domain.rb` has a dependency on ActiveSupports `present?` method. Adding ActiveSupport as a dependency in the gemspec (I'm guessing on the version number here; we could probably go lower but that isn't necessary for our use case).

# How to test
Unit tests were updated to ensure the returned domain has an expiration date that is greater than the original expiration date.

I also tested manually by:
* Log on to resellertest.enom.com with Login ID resellid, password resellpw. Find a domain to renew. Note this domain name as you'll need to paste the value in the next step.

* Create a file at `_project_root_/console.rb` with the contents:
```
require_relative 'lib/enom.rb'

Enom::Client.username = 'resellid'
Enom::Client.password = 'resellpw'
Enom::Client.test = true

# TODO: Update this to the domain name in the previous step
@domain_name = 'store-10000017.com' 

puts "Finding domain..."
@domain = Enom::Domain.find(@domain_name)
p @domain
puts

puts "Renewing domain..."
@renewed_domain = Enom::Domain.renew!(@domain_name)
p @renewed_domain
puts
```

2. Drop into a pry console (gem install pry if necessary) and run
```
$ load './console.rb'
```

Verify the domain's expiration date after the renew is different than the date in the original find request. 

Also, after refreshing the domain page in eNom a few times, the new date should be reflected.