### PR TITLE
Domain update_expired returns the domain's correct expiration date and status

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "enom"
-  s.version = "1.1.8"
+  s.version = "1.1.9"
   s.authors = ["James Miller"]
   s.summary = %q{Ruby wrapper for the Enom API}
   s.description = %q{Enom is a Ruby wrapper and command line interface for portions of the Enom domain reseller API.}

--- a/test/domain_test.rb
+++ b/test/domain_test.rb
@@ -189,6 +189,15 @@ class DomainTest < Test::Unit::TestCase
       should "renew the domain and return a domain object" do
         assert_equal @domain.name, "test123456test123456.com"
       end
+
+      should "return the domain reflecting the new expiration date" do
+        original_expiration_date = Enom::Domain.find('test123456test123456.com').expiration_date
+        assert_equal @domain.expiration_date, original_expiration_date.advance(years: 1)
+      end
+
+      should "return the domain reflecting the new regisration status" do
+        assert_true @domain.registration_status == "Registered"
+      end
     end
 
     context "finding a domain in your account" do


### PR DESCRIPTION
# What / Why
When a domain that has expired is renewed, find requests on that domain are not guaranteed to reflect the new expiration date and the new domain status. Now, when a domain is renewed, the found domain will have its expiration date advanced the number of years supplied to the `UpdateExpiredDomains` command and it's status updated to `Registered`.


# How to test
Unit tests were updated to ensure the returned domain's expiration date was advanced and has the correct status.

I also tested manually by:
* Log on to https://resellertest.enom.com/domains/DomainManager.asp?tab=expireddomains with Login ID resellid, password resellpw. Find an expired domain to renew. Note this domain name as you'll need to paste the value in the next step.

* Create a file at `_project_root_/console.rb` with the contents:
```
require_relative 'lib/enom.rb'

Enom::Client.username = 'resellid'
Enom::Client.password = 'resellpw'
Enom::Client.test = true

# TODO: Update this to the domain name in the previous step
@domain_name = '0592lh.com' 

puts "Finding domain..."
@domain = Enom::Domain.find(@domain_name)
p @domain
puts

puts "Renewing domain..."
@renewed_domain = Enom::Domain.renew!(@domain_name)
p @renewed_domain
puts
```

2. Drop into a pry console (gem install pry if necessary) and run
```
$ load './console.rb'
```

Verify the domain's expiration date after the renew is different than the date in the original find request. 

```
[1] pry(main)> load './console.rb'
Finding domain...
#<Enom::Domain:0x007f9c56f54de0 @name="0592lh.com", @sld="0592lh", @tld="com", @expiration_date=#<Date: 2016-03-03 ((2457451j,0s,0n),+0s,2299161j)>, @nameservers=nil, @registration_status="Expired">

Extending expired domain...
#<Enom::Domain:0x007f9c57b0ed98 @name="0592lh.com", @sld="0592lh", @tld="com", @expiration_date=#<Date: 2017-03-03 ((2457816j,0s,0n),+0s,2299161j)>, @nameservers=nil, @registration_status="Registered">

=> true
```

Also, after refreshing the domain page in eNom a few times, the new date should be reflected in the eNom A.UI.