### PR TITLE
Update public_suffix to 3.0.0

### DIFF
--- a/enom.gemspec
+++ b/enom.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files  = %w( README.md Rakefile LICENSE ) + ["lib/enom.rb"] + Dir.glob("lib/enom/*.rb") + Dir.glob("lib/enom/commands/*.rb") + Dir.glob("test/**/*") + Dir.glob("bin/*")
   s.has_rdoc = false
   s.add_dependency "httparty", "~> 0.10.0"
-  s.add_dependency "public_suffix", "~> 1.5.3"
+  s.add_dependency "public_suffix", "~> 3.0.0"
   s.add_dependency "activesupport", "> 4.2"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "shoulda"


### PR DESCRIPTION
Updates public_suffix to 3.0.0. This is needed for BRP-6041 to support .shop domains.

<img width="1499" alt="public_suffix_upgrade_test_results" src="https://user-images.githubusercontent.com/1090773/29792675-c1f0b80a-8c06-11e7-97b0-2b0ba14a22ec.png">

Confirmed the latest PublicSuffix parses .shop domains:
```
2.2.3 :003 > domain = PublicSuffix.parse('www.bill.shop')
 => #<PublicSuffix::Domain:0x007fdc1c8140e8 @tld="shop", @sld="bill", @trd="www">
```