### PR TITLE
add proxy support, update stuff and get tests passing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source "http://rubygems.org"
 
+# chrisk is updating it, but hasn't released a gem yet - see https://github.com/chrisk/fakeweb/issues/57#issuecomment-325515168
+# Once a gem is released, remove this line and uncomment the one in enom.gemspec
+gem 'fakeweb', git: 'https://github.com/chrisk/fakeweb.git'
 gem "jruby-openssl", :platform => :jruby
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Enom::Client.username = "foo"
 Enom::Client.password = "bar"
 Enom::Client.test = true
 # Declaring test mode is optional, defaults to false (production)
-# Test mode will run commands on Enom's reseller test platform
+# Test mode will run commands on Enom's resellertest.enom.com test platform
 ```
 
 Once these are set, subsequent commands will make calls to the API using your credentials (HTTPS).  Any methods in the library that charge or refund the account in any way end with a bang (!).
@@ -101,6 +101,18 @@ d.renew!
 # Renew domain for specific number of years
 d.renew!(:years => 3)
 ```
+
+## Host Override and Proxy/Tunnel Support
+
+If you want to use an HTTP proxy server to avoid having to add an IP to the Enom IP whitelist
+(which has been known to be slow/flaky to recognize new IPs), you can set the
+`proxyaddr` client option to point to your proxy server:
+
+```
+Enom::Client.proxyaddr = 'enom-proxy.example.com'
+```
+
+You can also optionally set `proxyport`, `proxyuser`, and `proxypass`.
 
 ## Copyright
 

--- a/bin/enom.rb
+++ b/bin/enom.rb
@@ -24,6 +24,12 @@ enom -u username -p password command
 You can run commands from the test interface with the -t flag:
 enom -u username -p password -t command
 
+You can set an http proxy host with the --proxyaddr flag, e.g. to use a proxy
+server with an already-whitelisted IP. You can also optionally specify
+the proxy port, user, and password.
+
+enom -u username -p password --proxyaddr enom-proxy.example.com --proxyport 1080 --proxyuser user --proxypass pass
+
 == Commands
 
 All commands are executed as enom [options] command [command-options] args
@@ -54,6 +60,18 @@ global = OptionParser.new do |opts|
   end
   opts.on("-t") do
     Enom::Client.test = true
+  end
+  opts.on("--proxyaddr [ARG]") do |proxyaddr|
+    Enom::Client.proxyaddr = proxyaddr
+  end
+  opts.on("--proxyport [ARG]") do |proxyport|
+    Enom::Client.proxyport = proxyport
+  end
+  opts.on("--proxyuser [ARG]") do |proxyuser|
+    Enom::Client.proxyuser = proxyuser
+  end
+  opts.on("--proxypass [ARG]") do |proxypass|
+    Enom::Client.proxypass = proxypass
   end
 end
 

--- a/enom.gemspec
+++ b/enom.gemspec
@@ -8,13 +8,15 @@ Gem::Specification.new do |s|
   s.email = "bensie@gmail.com"
   s.files  = %w( README.md Rakefile LICENSE ) + ["lib/enom.rb"] + Dir.glob("lib/enom/*.rb") + Dir.glob("lib/enom/commands/*.rb") + Dir.glob("test/**/*") + Dir.glob("bin/*")
   s.has_rdoc = false
-  s.add_dependency "httparty", "~> 0.10.0"
+  s.add_dependency "httparty", "~> 0.15"
   s.add_dependency "public_suffix", "~> 3.0.0"
   s.add_dependency "activesupport", "> 4.2"
   s.add_development_dependency "test-unit"
-  s.add_development_dependency "shoulda"
-  s.add_development_dependency "fakeweb"
-  s.add_development_dependency "rake", "~> 0.9"
+  s.add_development_dependency "shoulda", "~> 3.5"
+  # chrisk is updating fakeweb, but hasn't released a gem yet - see https://github.com/chrisk/fakeweb/issues/57#issuecomment-325515168
+  # Once a gem is released, remove the line in the Gemfile and uncomment this one
+  # s.add_development_dependency "fakeweb"
+  s.add_development_dependency "rake", "~> 12.0"
   s.executables = %w(enom)
   s.default_executable = "enom"
 end

--- a/lib/enom/client.rb
+++ b/lib/enom/client.rb
@@ -4,7 +4,7 @@ module Enom
     include HTTParty
 
     class << self
-      attr_accessor :username, :password, :test
+      attr_accessor :username, :password, :test, :proxyaddr, :proxyport, :proxyuser, :proxypass
       alias_method :test?, :test
 
       # All requests must contain the UID, PW, and ResponseType query parameters
@@ -24,6 +24,7 @@ module Enom
       # or other helpful statuses -- everything comes back as a 200.
       def request(params = {})
         params.merge!(default_params)
+        http_proxy(proxyaddr, proxyport, proxyuser, proxypass)
         response = get(base_uri, :query => params)
         case response.code
         when 200

--- a/lib/enom/domain.rb
+++ b/lib/enom/domain.rb
@@ -396,7 +396,7 @@ module Enom
     #
     # @raise [Enom::InterfaceError] If response is invalid
     def validate_response!(response)
-      unless response.is_a?(Hash) && response.key?('interface_response')
+      unless response.respond_to?(:key?) && response.key?('interface_response')
         raise Enom::InterfaceError, response.inspect
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -124,7 +124,7 @@ class Test::Unit::TestCase
     },
     {
       :command => "Check Many with default (*) TLD list (Success)",
-      :request => "https://reseller.enom.com/interface.asp?Command=Check&SLD=test123456test123456&TLD=*&TLDList=&UID=resellid&PW=resellpw&ResponseType=xml",
+      :request => "https://reseller.enom.com/interface.asp?Command=Check&SLD=test123456test123456&TLD=%2A&TLDList=&UID=resellid&PW=resellpw&ResponseType=xml",
       :response => <<-EOF
         <?xml version="1.0"?>
         <interface-response>


### PR DESCRIPTION
I added support for using an HTTP proxy to avoid having to whitelist enom servers when running prod servers in the cloud or running tests from public wifi.

Tests weren't passing for me, so this also includes a separate commit with changes I needed to get them to pass for me.  I can split them up into separate PRs if you wish.